### PR TITLE
Support for TRV10RFM and RX10RF

### DIFF
--- a/pyit600/gateway.py
+++ b/pyit600/gateway.py
@@ -165,7 +165,7 @@ class IT600Gateway:
                 filter(lambda x: "sIASZS" in x or
                                  ("sBasicS" in x and
                                   "ModelIdentifier" in x["sBasicS"] and
-                                  x["sBasicS"]["ModelIdentifier"] == "it600MINITRV"), all_devices["id"])
+                                  x["sBasicS"]["ModelIdentifier"] in ["it600MINITRV", "it600Receiver"]), all_devices["id"])
             )
 
             await self._refresh_binary_sensor_devices(binary_sensors, send_callback)
@@ -420,7 +420,7 @@ class IT600Gateway:
 
                 try:
                     model: Optional[str] = device_status.get("DeviceL", {}).get("ModelIdentifier_i", None)
-                    if model == "it600MINITRV":
+                    if model in ["it600MINITRV", "it600Receiver"]:
                         is_on: Optional[bool] = device_status.get("sIT600I", {}).get("RelayStatus", None)
                     else:
                         is_on: Optional[bool] = device_status.get("sIASZS", {}).get("ErrorIASZSAlarmed1", None)
@@ -440,6 +440,7 @@ class IT600Gateway:
                             "moisture" if model == "WLS600" else
                             "smoke" if model == "SmokeSensor-EM" else
                             "valve" if model == "it600MINITRV" else
+                            "receiver" if model == "it600Receiver" else
                             None,
                         data=device_status["data"],
                         manufacturer=device_status.get("sBasicS", {}).get("ManufactureName", "SALUS"),


### PR DESCRIPTION
I've added support for TRV10RFM (radiator valve) and RX10RF (boiler receiver) as binary sensor devices to show when they are on/off. 
Since they are categorised as sensors, the on/off value is read only, it cannot be set.

The exact models, TRV10RFM and RX10RF, are not mentioned in the response from the gateway, so it's likely that this change will add support for more than these two, but I only have these to test with. For example, there's TRV28RFM which looks like it only differs from TRV10RFM in the diameter of the attachment point. The exact models reported by the gateway are:

- TRV10RFM reported as model `it600MINITRV`
- RX10RF reported as model `it600Receiver`

In theory, both of them receive commands to open/close, but I haven't figured out a way to do it via the gateway API. There's also no way to control them from the mobile app, so my guess is that it's not possible at all to control them through the API.