### PR TITLE
Fixing the pyit600 errors on connection and improving the gateway json response

### DIFF
--- a/pyit600/gateway.py
+++ b/pyit600/gateway.py
@@ -929,7 +929,12 @@ class IT600Gateway:
                     response_json_string = self._encryptor.decrypt(response_bytes)
 
                     if self._debug:
-                        _LOGGER.debug("Gateway response:\n%s\n", response_json_string)
+                        try:
+                            response_json = json.loads(response_json_string)  # Parse the string into JSON
+                            _LOGGER.debug("Gateway response:\n%s\n", json.dumps(response_json, indent=4))  # Pretty print JSON
+                        except json.JSONDecodeError as e:
+                            _LOGGER.error("Failed to decode JSON response: %s\n", e)
+                            _LOGGER.debug("Raw Gateway response:\n%s\n", response_json_string)
 
                     response_json = json.loads(response_json_string)
 

--- a/pyit600/gateway.py
+++ b/pyit600/gateway.py
@@ -402,7 +402,7 @@ class IT600Gateway:
 
     async def _refresh_binary_sensor_devices(self, devices: List[Any], send_callback=False):
         local_devices = {}
-        _LOGGER.debug(f"!!!!!!! _refresh_binary_sensor_devices: {devices}")
+        _LOGGER.debug(f"Logging  _refresh_binary_sensor_devices: {devices}")
 
         if devices:
             status = await self._make_encrypted_request(
@@ -425,10 +425,11 @@ class IT600Gateway:
                         is_on: Optional[bool] = device_status.get("sIT600I", {}).get("RelayStatus", None)
                     elif model == "SmokeSensor-EM":
                         # First try to get the standard alarm attribute
-                        is_on = Optional[bool] = device_status.get("sIASZS", {}).get("ErrorIASZSAlarmed1", None)
+                        is_on: Optional[bool] = device_status.get("sIASZS", {}).get("ErrorIASZSAlarmed1", None)
                         # If it doesn't exist, default to 0 (not alarmed)
                         if is_on is None:
                             is_on = 0
+                        _LOGGER.debug(f"Smoke sensor is_on: {is_on}")
                     else:
                         is_on: Optional[bool] = device_status.get("sIASZS", {}).get("ErrorIASZSAlarmed1", None)
 

--- a/pyit600/gateway.py
+++ b/pyit600/gateway.py
@@ -424,9 +424,11 @@ class IT600Gateway:
                     if model in ["it600MINITRV", "it600Receiver"]:
                         is_on: Optional[bool] = device_status.get("sIT600I", {}).get("RelayStatus", None)
                     elif model == "SmokeSensor-EM":
-                        # You'll need to set a default state or find the correct attribute
-                        # This assumes the sensor is off by default
-                        is_on = 0  # or use some other attribute that indicates the alarm state
+                        # First try to get the standard alarm attribute
+                        is_on = Optional[bool] = device_status.get("sIASZS", {}).get("ErrorIASZSAlarmed1", None)
+                        # If it doesn't exist, default to 0 (not alarmed)
+                        if is_on is None:
+                            is_on = 0
                     else:
                         is_on: Optional[bool] = device_status.get("sIASZS", {}).get("ErrorIASZSAlarmed1", None)
 

--- a/pyit600/gateway.py
+++ b/pyit600/gateway.py
@@ -119,7 +119,7 @@ class IT600Gateway:
             return gateway["sGateway"]["NetworkLANMAC"]
         except IT600ConnectionError as ae:
             try:
-                with async_timeout.timeout(self._request_timeout):
+                async with async_timeout.timeout(self._request_timeout):
                     await self._session.get(f"http://{self._host}:{self._port}/")
             except Exception:
                 raise IT600ConnectionError(
@@ -919,7 +919,7 @@ class IT600Gateway:
                 if self._debug:
                     _LOGGER.debug("Gateway request: POST %s\n%s\n", request_url, request_body_json)
 
-                with async_timeout.timeout(self._request_timeout):
+                async with async_timeout.timeout(self._request_timeout):
                     resp = await self._session.post(
                         request_url,
                         data=self._encryptor.encrypt(request_body_json),
@@ -953,7 +953,7 @@ class IT600Gateway:
                     "check if you have specified host/IP address correctly"
                 ) from e
             except Exception as e:
-                _LOGGER.error("Exception. %s / %s", type(e), repr(e.args), e)
+                _LOGGER.error("Exception: %s", repr(e))
                 raise IT600CommandError(
                     "Unknown error occurred while communicating with iT600 gateway"
                 ) from e


### PR DESCRIPTION
**Before the fixes**

`root@32f54c65cdfe:/app/pyit600# python main.py --host 192.168.150.255 --euid xxxxxx --debug
DEBUG:pyit600:Trying to connect to gateway at 192.168.150.255
DEBUG:pyit600:Gateway request: POST http://192.168.150.255:80/deviceid/read
{"requestAttr": "readall"}

--- Logging error ---
Traceback (most recent call last):
  File "/app/pyit600/pyit600/gateway.py", line 922, in _make_encrypted_request
    with async_timeout.timeout(self._request_timeout):
AttributeError: __enter__

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File "/usr/local/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/app/pyit600/main.py", line 172, in <module>
    asyncio.run(main())
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 636, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 603, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 1909, in _run_once
    handle._run()
  File "/usr/local/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/app/pyit600/main.py", line 72, in main
    await gateway.connect()
  File "/app/pyit600/pyit600/gateway.py", line 101, in connect
    all_devices = await self._make_encrypted_request(
  File "/app/pyit600/pyit600/gateway.py", line 956, in _make_encrypted_request
    _LOGGER.error("Exception. %s / %s", type(e), repr(e.args), e)
Message: 'Exception. %s / %s'
Arguments: (<class 'AttributeError'>, "('__enter__',)", AttributeError('__enter__'))
Traceback (most recent call last):
  File "/app/pyit600/pyit600/gateway.py", line 922, in _make_encrypted_request
    with async_timeout.timeout(self._request_timeout):
AttributeError: __enter__

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/pyit600/main.py", line 172, in <module>
    asyncio.run(main())
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/app/pyit600/main.py", line 72, in main
    await gateway.connect()
  File "/app/pyit600/pyit600/gateway.py", line 101, in connect
    all_devices = await self._make_encrypted_request(
  File "/app/pyit600/pyit600/gateway.py", line 957, in _make_encrypted_request
    raise IT600CommandError(
pyit600.exceptions.IT600CommandError: Unknown error occurred while communicating with iT600 gateway
`

**After the fixes**

`root@32f54c65cdfe:/app/pyit600# python main.py --host 192.168.150.185 --euid xxxxxxx--debug
DEBUG:pyit600:Trying to connect to gateway at 192.168.150.255
DEBUG:pyit600:Gateway request: POST http://192.168.150.255:80/deviceid/read
{"requestAttr": "readall"}

DEBUG:pyit600:Gateway response:
{"id":[{"data":{"DeviceType":100,"Endpoint":1,"UniID":"xxx"},"sGenSche":{"UpdateGenScheStatus":0},"DeviceL":{"DeviceType":100,"getModelIdentifierFlag_i":1,"DeviceSubType":1026,"UnquieID":"xxxx","ClusterIDList_i":"xxxx#","AttributeList":"xxxx" 
..............`

Please let me know if you see something that should be also changed/improved